### PR TITLE
Fix Gemini API key lookup

### DIFF
--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,7 +1,9 @@
 
 import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
 
-const API_KEY = process.env.API_KEY;
+// Prefer the explicitly named GEMINI_API_KEY but fall back to API_KEY for
+// backward compatibility with older environment setups.
+const API_KEY = process.env.GEMINI_API_KEY || process.env.API_KEY;
 
 if (!API_KEY) {
   console.warn("API_KEY for Gemini is not set. Description generation will be disabled.");


### PR DESCRIPTION
## Summary
- support `GEMINI_API_KEY` environment variable in gemini service

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686814de0adc8322b9ab36088d82e30f