### PR TITLE
Add August 26 2025 lab results data

### DIFF
--- a/public/blood_data.json
+++ b/public/blood_data.json
@@ -95,7 +95,7 @@
       "date": "2025-08-26",
       "value": 14.9,
       "unit": "g/dL",
-      "refRange": "[13.0-17.0]"
+      "refRange": "[13.0-17.5]"
     }
   ],
   "Hematies": [
@@ -107,9 +107,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 4.88,
+      "value": 4.83,
       "unit": "10^12/L",
-      "refRange": "[4.60-6.00]"
+      "refRange": "[4.40-5.90]"
     }
   ],
   "Hematocrito": [
@@ -293,7 +293,7 @@
     },
     {
       "date": "2025-08-26",
-      "value": 88.1,
+      "value": 89.0,
       "unit": "fL",
       "refRange": "[80.0-100.0]"
     }
@@ -386,9 +386,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 30.5,
+      "value": 30.9,
       "unit": "pg",
-      "refRange": "[27.0-32.0]"
+      "refRange": "[26.6-33.8]"
     }
   ],
   "CHCM": [
@@ -481,7 +481,7 @@
       "date": "2025-08-26",
       "value": 34.7,
       "unit": "g/dL",
-      "refRange": "[32.0-36.0]"
+      "refRange": "[31.5-36.3]"
     }
   ],
   "ADE/RDW": [
@@ -578,9 +578,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 13.0,
+      "value": 15.8,
       "unit": "%",
-      "refRange": "[11.5-14.5]"
+      "refRange": "[12.00-15.00]"
     }
   ],
   "Leucocitos": [
@@ -679,7 +679,7 @@
       "date": "2025-08-26",
       "value": 7.78,
       "unit": "10^9/L",
-      "refRange": "[4.0-11.0]"
+      "refRange": "[3.80-11.00]"
     }
   ],
   "Neutrofilos (%)": [
@@ -776,9 +776,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 55.0,
+      "value": 45.6,
       "unit": "%",
-      "refRange": "[40.0-70.0]"
+      "refRange": "[40.0-77.0]"
     }
   ],
   "Linfocitos (%)": [
@@ -875,9 +875,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 33.0,
+      "value": 35.0,
       "unit": "%",
-      "refRange": "[20.0-45.0]"
+      "refRange": "[16.0-44.0]"
     }
   ],
   "Monocitos (%)": [
@@ -974,9 +974,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 6.0,
+      "value": 11.3,
       "unit": "%",
-      "refRange": "[2.0-10.0]"
+      "refRange": "[4.0-10.0]"
     }
   ],
   "Eosinofilos (%)": [
@@ -1067,9 +1067,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 4.0,
+      "value": 5.6,
       "unit": "%",
-      "refRange": "[0.0-6.0]"
+      "refRange": "[1.0-7.0]"
     }
   ],
   "Basofilos (%)": [
@@ -1160,9 +1160,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 1.0,
+      "value": 1.7,
       "unit": "%",
-      "refRange": "[0.0-2.0]"
+      "refRange": "[0.0-1.0]"
     }
   ],
   "Neutrofilos (Absoluto)": [
@@ -1253,9 +1253,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 4.28,
+      "value": 3.54,
       "unit": "10^9/L",
-      "refRange": "[1.80-7.30]"
+      "refRange": "[1.80-11.00]"
     }
   ],
   "Linfocitos (Absoluto)": [
@@ -1346,9 +1346,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 2.57,
+      "value": 2.72,
       "unit": "10^9/L",
-      "refRange": "[1.00-4.80]"
+      "refRange": "[1.00-5.00]"
     }
   ],
   "Monocitos (Absoluto)": [
@@ -1439,9 +1439,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 0.47,
+      "value": 0.88,
       "unit": "10^9/L",
-      "refRange": "[0.10-1.00]"
+      "refRange": "[0.00-1.00]"
     }
   ],
   "Eosinofilos (Absoluto)": [
@@ -1453,9 +1453,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 0.31,
+      "value": 0.44,
       "unit": "10^9/L",
-      "refRange": "[0.00-0.60]"
+      "refRange": "[0.00-0.45]"
     }
   ],
   "Basofilos (Absoluto)": [
@@ -1467,7 +1467,7 @@
     },
     {
       "date": "2025-08-26",
-      "value": 0.15,
+      "value": 0.13,
       "unit": "10^9/L",
       "refRange": "[0.00-0.20]"
     }
@@ -1566,9 +1566,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 217,
+      "value": 313.0,
       "unit": "10^9/L",
-      "refRange": "[150-450]"
+      "refRange": "[130.0-450.0]"
     }
   ],
   "Glucosa": [
@@ -1665,7 +1665,7 @@
     },
     {
       "date": "2025-08-26",
-      "value": 102,
+      "value": 79.0,
       "unit": "mg/dL",
       "refRange": "[70-110]"
     }
@@ -1764,9 +1764,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 45,
+      "value": 55.0,
       "unit": "mg/dL",
-      "refRange": "[20-50]"
+      "refRange": "[10-45]"
     }
   ],
   "Creatinina": [
@@ -1863,9 +1863,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 1.17,
+      "value": 1.21,
       "unit": "mg/dL",
-      "refRange": "[0.70-1.20]"
+      "refRange": "[0.70-1.30]"
     }
   ],
   "Filtrado Glomerular": [
@@ -1877,9 +1877,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 75,
+      "value": 71.65,
       "unit": "mL/min",
-      "refRange": "> 60"
+      "refRange": ">60"
     }
   ],
   "Sodio": [
@@ -1976,7 +1976,7 @@
     },
     {
       "date": "2025-08-26",
-      "value": 142,
+      "value": 142.0,
       "unit": "mmol/L",
       "refRange": "[132-146]"
     }
@@ -2075,9 +2075,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 4.8,
+      "value": 4.9,
       "unit": "mmol/L",
-      "refRange": "[3.5-5.1]"
+      "refRange": "[3.5-5.5]"
     }
   ],
   "Cloro": [
@@ -2162,9 +2162,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 103,
+      "value": 103.0,
       "unit": "mmol/L",
-      "refRange": "[98-107]"
+      "refRange": "[95-110]"
     }
   ],
   "Calcio": [
@@ -2253,19 +2253,19 @@
       "date": "2025-08-26",
       "value": 9.5,
       "unit": "mg/dL",
-      "refRange": "[8.4-10.5]"
+      "refRange": "[8.8-10.5]"
     }
   ],
   "Fosforo": [
     {
-      "date": "2025-03-05",
-      "value": 3.4,
+      "date": "2025-02-12",
+      "value": 2.4,
       "unit": "mg/dL",
       "refRange": "[2.5-4.5]"
     },
     {
-      "date": "2025-02-12",
-      "value": 2.4,
+      "date": "2025-03-05",
+      "value": 3.4,
       "unit": "mg/dL",
       "refRange": "[2.5-4.5]"
     },
@@ -2307,9 +2307,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 2.2,
+      "value": 4.2,
       "unit": "mg/dL",
-      "refRange": "[2.5-4.5]"
+      "refRange": "[2.4-5.1]"
     }
   ],
   "Magnesio": [
@@ -2358,6 +2358,12 @@
     {
       "date": "2025-07-02",
       "value": 2,
+      "unit": "mg/dL",
+      "refRange": "[1.8-2.4]"
+    },
+    {
+      "date": "2025-08-26",
+      "value": 2.0,
       "unit": "mg/dL",
       "refRange": "[1.8-2.4]"
     }
@@ -2450,9 +2456,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 0.6,
+      "value": 0.7,
       "unit": "mg/dL",
-      "refRange": "[0.2-1.2]"
+      "refRange": "[0.0-1.1]"
     }
   ],
   "GOT/AST": [
@@ -2536,9 +2542,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 22,
+      "value": 22.0,
       "unit": "U/L",
-      "refRange": "[0-40]"
+      "refRange": "[0-37]"
     }
   ],
   "GPT/ALT": [
@@ -2629,9 +2635,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 27,
+      "value": 26.0,
       "unit": "U/L",
-      "refRange": "[0-41]"
+      "refRange": "[0-49]"
     }
   ],
   "GGT": [
@@ -2715,9 +2721,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 61,
+      "value": 106.0,
       "unit": "U/L",
-      "refRange": "[8-61]"
+      "refRange": "[5-85]"
     }
   ],
   "Fosfatasa Alcalina": [
@@ -2801,9 +2807,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 74,
+      "value": 59.0,
       "unit": "U/L",
-      "refRange": "[40-129]"
+      "refRange": "[40-136]"
     }
   ],
   "LDH": [
@@ -2887,9 +2893,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 223,
+      "value": 240.0,
       "unit": "U/L",
-      "refRange": "[135-225]"
+      "refRange": "[120-241]"
     }
   ],
   "Proteinas Totales": [
@@ -2973,9 +2979,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 7.5,
+      "value": 7.0,
       "unit": "g/dL",
-      "refRange": "[6.6-8.7]"
+      "refRange": "[6.4-8.2]"
     }
   ],
   "Albumina": [
@@ -3066,9 +3072,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 4.5,
+      "value": 4.6,
       "unit": "g/dL",
-      "refRange": "[3.5-5.2]"
+      "refRange": "[3.4-5.0]"
     }
   ],
   "Acido Urico": [
@@ -3149,6 +3155,12 @@
       "value": 6.4,
       "unit": "mg/dL",
       "refRange": "[2.6-7.2]"
+    },
+    {
+      "date": "2025-08-26",
+      "value": 7.1,
+      "unit": "mg/dL",
+      "refRange": "[2.6-7.2]"
     }
   ],
   "Hierro": [
@@ -3190,9 +3202,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 119,
+      "value": 115.0,
       "unit": "µg/dL",
-      "refRange": "[59-158]"
+      "refRange": "[35-150]"
     }
   ],
   "Proteina C Reactiva": [
@@ -3446,7 +3458,7 @@
     },
     {
       "date": "2025-08-26",
-      "value": 257,
+      "value": 257.0,
       "unit": "mg/dL",
       "refRange": "[140-200]"
     }
@@ -3460,7 +3472,7 @@
     },
     {
       "date": "2025-08-26",
-      "value": 51,
+      "value": 52.0,
       "unit": "mg/dL",
       "refRange": "[35-60]"
     }
@@ -3474,9 +3486,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 190,
+      "value": 168.1,
       "unit": "mg/dL",
-      "refRange": "<155.00"
+      "refRange": "[0.00-155.00]"
     }
   ],
   "VLDL-Colesterol": [
@@ -3488,7 +3500,7 @@
     },
     {
       "date": "2025-08-26",
-      "value": 16,
+      "value": 37.4,
       "unit": "mg/dL",
       "refRange": "[10.00-32.00]"
     }
@@ -3508,7 +3520,7 @@
     },
     {
       "date": "2025-08-26",
-      "value": 82,
+      "value": 187.0,
       "unit": "mg/dL",
       "refRange": "[50-160]"
     }
@@ -3530,9 +3542,9 @@
     },
     {
       "date": "2025-08-26",
-      "value": 32.0,
+      "value": 12.7,
       "unit": "%",
-      "refRange": "[15.0-65.0]"
+      "refRange": "[15.00-65.00]"
     }
   ],
   "Cociente N/L": [
@@ -3544,9 +3556,25 @@
     },
     {
       "date": "2025-08-26",
-      "value": 1.7,
+      "value": 1.3,
       "unit": "",
       "refRange": "[0.8-3.5]"
+    }
+  ],
+  "Volumen Plaquetar Medio": [
+    {
+      "date": "2025-08-26",
+      "value": 9.4,
+      "unit": "fL",
+      "refRange": "[7.2-11.1]"
+    }
+  ],
+  "Plaquetocrito": [
+    {
+      "date": "2025-08-26",
+      "value": 0.29,
+      "unit": "%",
+      "refRange": "[0.100-0.400]"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- append the 26/08/2025 hematology values (hemoglobina, hematíes, leucograma y plaquetas) into `public/blood_data.json`
- record the same day's biochemical, renal, electrolyte and lipid panel measurements so charts include the latest checkup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd0c6369d8832299ddbafa1f3fdda9