### PR TITLE
Refactor parameter effect dependencies

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -54,9 +54,22 @@ const App: React.FC = () => {
         if (!latest) {
           return current;
         }
+
         const latestDate = parseDateValue(latest.date).getTime();
         const currentDate = parseDateValue(current.date).getTime();
-        return currentDate > latestDate ? current : latest;
+
+        const latestDateIsNaN = Number.isNaN(latestDate);
+        const currentDateIsNaN = Number.isNaN(currentDate);
+
+        if (latestDateIsNaN && !currentDateIsNaN) {
+          return current;
+        }
+
+        if (currentDateIsNaN) {
+          return latest;
+        }
+
+        return currentDate >= latestDate ? current : latest;
       }, null);
 
       if (latestDataPoint) {


### PR DESCRIPTION
## Summary
- recompute available parameters and flags using a reduce-based latest point lookup that only depends on bloodTestData
- initialize the selected parameter from a dedicated effect that watches available parameters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5142a9bfc8322a01ef35326f239de